### PR TITLE
PEP 8, docformater and .gitignore

### DIFF
--- a/src/instabot.py
+++ b/src/instabot.py
@@ -183,21 +183,27 @@ class InstaBot:
         self.write_log(log_string)
         self.login()
         self.populate_user_blacklist()
-        signal.signal(signal.SIGTERM, self.cleanup)
-        atexit.register(self.cleanup)
+        # signal.signal(signal.SIGTERM, self.cleanup)
+        # atexit.register(self.cleanup)
 
     def populate_user_blacklist(self):
         for user in self.user_blacklist:
 
-            user_id_url= self.url_user_detail % (user)
+            user_id_url = self.url_user_detail % (user)
             info = self.s.get(user_id_url)
-            all_data = json.loads(info.text)
-            id_user = all_data['user']['media']['nodes'][0]['owner']['id']
-            #Update the user_name with the user_id
-            self.user_blacklist[user]=id_user
-            log_string = "Blacklisted user %s added with ID: %s" % (user, id_user)
-            self.write_log(log_string)
-            time.sleep(5 * random.random())
+            # Valiaditon if user exists
+            if info.status_code == 404:
+                # if not exists show test
+                log_string = "User {} from the blacklist does not exist".format(user)
+            else:
+                # f user exists continue normal
+                all_data = json.loads(info.text)
+                id_user = all_data['user']['media']['nodes'][0]['owner']['id']
+                #Update the user_name with the user_id
+                self.user_blacklist[user]=id_user
+                log_string = "Blacklisted user %s added with ID: %s" % (user, id_user)
+                self.write_log(log_string)
+                time.sleep(5 * random.random())
 
         log_string = "Completed populating user blacklist with IDs"
         self.write_log(log_string)


### PR DESCRIPTION
Nowadays the project does not possess the standar of pep 8 that it suggests python that it should follow, besides that the comments do not expire with the format PEP257, take the time of estandarisarlo, beside integrating a gitignore not to raise the files of cache to the repository .

Test: 

Ubuntu 16.01 python 3.4 & 2.7
MAC Capitan  python 3.4 && 2.7